### PR TITLE
Add pre post

### DIFF
--- a/AnsiWrap.usc
+++ b/AnsiWrap.usc
@@ -94,11 +94,11 @@ if bill-parm !DP and promptforparm = "Y" then
 endif
 
 ' panic if we still don't have a bill parm
-'if nsa837p5parm !dp and requirebillparm != "N" then
-   'ShowMessageWin("Billing Parm File Not Specified",,"Print this Screen and Contact MIS")
-   'retcode = 98
-   'return
-'endif
+if bill-parm !dp then
+   ShowMessageWin("Billing Parm File Not Specified",,"Print this Screen and Contact MIS")
+   retcode = 98
+   return
+endif
 
 'check the billing parm file for the parameter "SEQOUT", if it is present, put the value into the CheckFile variable.
 'We should probably do some error checking to handle situations when the SEQOUT parmaeter is not present.  If this is the case, 
@@ -108,14 +108,6 @@ if $getparm(,bill-parm, "SEQOUT", CheckFile) >= 2 then
    ShowMessageWin("SEQOUT Parm Not in Parmfile",,"Print this Screen and Contact MIS")
    return
 endif
-
-' Use the filename from the parameter file if not overritten in this script.
-'if CheckFile DP and FileName !DP then
-   'FileName = CheckFile
-'else
-   'CheckFile = FileName
-   'FileName = FilePath + FileName
-'endif
 
 'Check to see if the file is there.  If it is, give the error message and terminate the script.
 'If it is not, allow the 837P proess to continue with the parm in Add Parm 1.
@@ -137,15 +129,13 @@ if rc = 0                 'If the file already exists, issue the error message a
    return
 endif                
 
-'If the billfile is not there, go ahead and dynamically create the bill parm that tells the process to run as
-'5010 or 4010
-
 'process the prescripts
 rc = 0
 do while rc++ < $maxarray(prescript[])
    call prescript[rc] (parmfile, option, checkfile, retcode)
 enddo
 
+'dynamically create the bill parm that tells the process to run as 5010 if we don't have a NSA parameter
 verparm = parmfile
 if nsa837p5parm !dp then
    ParmArray[1] = "NSA837P5"
@@ -155,7 +145,6 @@ if nsa837p5parm !dp then
 endif
 
 CreateBill = $misprog(474,VerParm)
-'createbill = $misprog(474, parmfile)
 
 if createbill > 0 then
    $errmsg1 = misprogerr[rc]

--- a/AnsiWrap.usc
+++ b/AnsiWrap.usc
@@ -24,26 +24,29 @@ start AnsiWrap()
 
 'Define the parameters we'll need.
 
-win1		     is b	'Window Handle number
-rc		       is i	'Function return codes
-CreateBill	 is b	'Error code from $misprog
-FileName	   is x	'Name of output file
-CheckFile	   is x	'Output file name & path
-FilePath	   is x	'path to output file
-FileSize	   is n
-FileCreateDT is d
-FileCreateTM is t
-FileOwner	   is x
-BillParm	   is x
-FixCMD		   is x	'Unix command for fixing output file
-ParmArray[]	 is x	'Array for building a parameter file
-VerParm		   is x	'Parameter file name
-bill_parm    is x  'Billing Parm file to use selected from either $adparm1 or $adparm2
+win1           is b   'Window Handle number
+rc             is i   'Function return codes
+CreateBill     is b   'Error code from $misprog
+FileName       is x   'Name of output file
+CheckFile      is x   'Output file name & path
+FilePath       is x   'path to output file
+FileSize       is n
+FileCreateDT   is d
+FileCreateTM   is t
+FileOwner      is x
+BillParm       is x
+FixCMD         is x   'Unix command for fixing output file
+Version        is x   '5010 or 4010
+ParmArray[]    is x   'Array for building a parameter file
+VerParm        is x   'Parameter file name
+bill_parm      is x   'Billing Parm file to use selected from either $adparm1 or $adparm2
+tempfile       is x   'Temporary file for the FixCmd
+dofield013     is x   'Flag to turn on using Field Record 102 Field 113.
 
 'Check to make sure the Add Parm 1 menu item has something there.  If not, give the error message and terminate the script.
 if $adparm1  !DP
-	ShowMessageWin("Please Add Billing Parm File to Add Parm 1",,"Print this Screen and Contact MIS")
-	return
+   ShowMessageWin("Please Add Billing Parm File to Add Parm 1",,"Print this Screen and Contact MIS")
+   return
 endif
 
 'Check that the Add Parm 1 value is something we expect.  If not, give the error message and terminate the script.
@@ -58,16 +61,16 @@ bill_parm = $adparm1
 rc = $getparm(,bill_parm, "SEQOUT", CheckFile)
 
 if rc >= 2
-	ShowMessageWin("SEQOUT Parm Not in Parmfile",,"Print this Screen and Contact MIS")
-	return
+   ShowMessageWin("SEQOUT Parm Not in Parmfile",,"Print this Screen and Contact MIS")
+   return
 endif
 
 ' Use the filename from the parameter file if not overritten in this script.
 if CheckFile DP and FileName !DP then
-	FileName = CheckFile
+   FileName = CheckFile
 else
-	CheckFile = FileName
-	FileName = FilePath + FileName
+   CheckFile = FileName
+   FileName = FilePath + FileName
 endif
 
 'Check to see if the file is there.  If it is, give the error message and terminate the script.
@@ -76,59 +79,70 @@ endif
 rc = $checkfile(FileName,FileSize,FileCreateDT,FileCreateTM,,,FileOwner)
 
 if rc = 0                 'If the file already exists, issue the error message and instructions to the user
-	$openwin(win1, 5, 25, 4, 64)
-	$disp("Script ID:", 6, 5,,"H")
-	$disp($scriptid,    6,16,,)
-	$disp(`"FILE REPLACEMENT ERROR, " + CheckFile + " File Exists!"`, 7, 5,,"H")
-	$disp(`"File Size:  " + FileSize + " bytes"`, 9, 5,,"H")
-	$disp(`"File Date:  " + FileCreateDT`, 10, 5,,"H")
-	$disp(`"File Time:  " + FileCreateTM`, 11, 5,,"H")
-	$disp(`"File Owner: " + FileOwner`, 12, 5,,"H")
-	$disp("Print this Screen and Contact MIS", 19, 5,,"H")
-	$acpt()
+   $openwin(win1, 5, 25, 4, 64)
+   $disp("Script ID:", 6, 5,,"H")
+   $disp($scriptid,    6,16,,)
+   $disp(`"FILE REPLACEMENT ERROR, " + CheckFile + " File Exists!"`, 7, 5,,"H")
+   $disp(`"File Size:  " + FileSize + " bytes"`, 9, 5,,"H")
+   $disp(`"File Date:  " + FileCreateDT`, 10, 5,,"H")
+   $disp(`"File Time:  " + FileCreateTM`, 11, 5,,"H")
+   $disp(`"File Owner: " + FileOwner`, 12, 5,,"H")
+   $disp("Print this Screen and Contact MIS", 19, 5,,"H")
+   $acpt()
 	return
 endif                
 
 'If the billfile is not there, go ahead and dynamically create the bill parm that tells the process to run as
 '5010 or 4010
 
-		ParmArray[1] = "NSA837P5"
-		ParmArray[2] = "NSA837P5PARM " + bill_parm
-		VerParm = "VP5010"
+   ParmArray[1] = "NSA837P5"
+   ParmArray[2] = "NSA837P5PARM " + bill_parm
+   VerParm = "VP5010"
 
-	rc = $putparm(ParmArray[],VerParm,"R")
+   rc = $putparm(ParmArray[],VerParm,"R")
 
-	CreateBill = $misprog(474,VerParm)
-'	CreateBill = $misprog(474,bill_parm)
-	
-		' Show a error message
-		select CreateBill
-		  case 0  goto EndScript
-		  case 1	$errmsg1 = "The mis-prog-ref isn't in the program control file"
-		  case 2	$errmsg1 = "Operator isn't authorized to initiate this program"
-		  case 3 	$errmsg1 = "This function isn't permitted if $sessiontabs is active"
-		  case 4	$errmsg1 = "The program attempted is not allowed in $misprog (e.g. menu)"
-		  case 5 	$errmsg1 = "$misprog cannot be executed while $setmis is in effect"
-		  case 6 	$errmsg1 = "Program is browser only and session is in character mode"
-		  case 7 	$errmsg1 = "Program is non-browser mode and session is in browser mode"
-		  case 8	$errmsg1 = "Error bidding the CMHC/MIS program"
-		  case 9	$errmsg1 = "Program control file error"
-		  case 10	$errmsg1 = "The session is a CRON, but the requested CMHC/MIS program cannot be run in CRON mode"
-		  case 11	$errmsg1 = "More than one left-frame menu referenced"
-		  case other	$errmsg1 = $format(rc, "Unknown error (99)")
-		endselect
+   CreateBill = $misprog(474,VerParm)
+   if CreateBill = 0 then
+
+      rc = $tempfile(tempfile)
+      FixCmd = "sed 's/BK:ICD10:/ABK:/g' " + Filename + " > " + tempfile + " ; cp " + tempfile + " " + Filename
+
+      ' Have a post fix command to run
+      if FixCMD DP then
+         if dofield013 = "Y"
+            rc = $unix(FixCmd)         
+         endif
+      endif
+   else
+      ' Show a error message
+      select CreateBill
+         case 1         $errmsg1 = "The mis-prog-ref isn't in the program control file"
+         case 2         $errmsg1 = "Operator isn't authorized to initiate this program"
+         case 3         $errmsg1 = "This function isn't permitted if $sessiontabs is active"
+         case 4         $errmsg1 = "The program attempted is not allowed in $misprog (e.g. menu)"
+         case 5         $errmsg1 = "$misprog cannot be executed while $setmis is in effect"
+         case 6         $errmsg1 = "Program is browser only and session is in character mode"
+         case 7         $errmsg1 = "Program is non-browser mode and session is in browser mode"
+         case 8         $errmsg1 = "Error bidding the CMHC/MIS program"
+         case 9         $errmsg1 = "Program control file error"
+         case 10        $errmsg1 = "The session is a CRON, but the requested CMHC/MIS program cannot be run in CRON mode"
+         case 11        $errmsg1 = "More than one left-frame menu referenced"
+         case other     $errmsg1 = $format(rc, "Unknown error (99)")
+      endselect
+   endif
+endif
 
 EndScript:
 end AnsiWrap
 
 function ShowMessageWin(msg1, msg2, msg3, msg4) is null
 '--- function arguments ---
-msg1		is x	' Message line one
-msg2		is x	' Message line two
-msg3		is x	' Message line three
-msg4		is x 	' Message line four
+msg1      is x   ' Message line one
+msg2      is x   ' Message line two
+msg3      is x   ' Message line three
+msg4      is x    ' Message line four
 ' --- Local Variables ---
-win1		is b	' Window Number
+win1      is b   ' Window Number
 '------------------------
 $openwin(win1, 5, 12, 4, 64)
 $disp("Script ID:", 6,  6,,"H")

--- a/AnsiWrap.usc
+++ b/AnsiWrap.usc
@@ -1,5 +1,5 @@
-start AnsiWrap()
- %VERSION 1.0.000 09/16/2015
+start AnsiWrap(parmfile, option, retcode)
+ %VERSION 0.4.000 10/08/2015
 'Author:  R. Whaite, Helen Farabee Centers
 'Create Date:  8/16/2011
 '
@@ -16,13 +16,12 @@ start AnsiWrap()
 'A UNIX Command can be defined that will make those changes to the file.  Otherwise, do not set a value for the 
 'variable "FixCMD"
 
-'When adding this script to a menu.  466 is the program number, enter this script name "AnsiWrap()" in the parameter feild 
-'and enter the bill parm name in the Add Parm 1 field. 
-
-'$trace("path","/c4/EXPORT2/trace/AnsiWrap.txt")
-'$trace("on")
-
 'Define the parameters we'll need.
+parmfile       is x
+option         is x
+retcode        is b
+
+$allowupdate(retcode)
 
 win1           is b   'Window Handle number
 rc             is i   'Function return codes
@@ -41,26 +40,36 @@ ParmArray[]    is x   'Array for building a parameter file
 VerParm        is x   'Parameter file name
 bill_parm      is x   'Billing Parm file to use selected from either $adparm1 or $adparm2
 tempfile       is x   'Temporary file for the FixCmd
-dofield013     is x   'Flag to turn on using Field Record 102 Field 113.
 
-'Check to make sure the Add Parm 1 menu item has something there.  If not, give the error message and terminate the script.
-if $adparm1  !DP
-   ShowMessageWin("Please Add Billing Parm File to Add Parm 1",,"Print this Screen and Contact MIS")
-   return
+tracepath      is x
+promptforparm  is x
+
+'Default the bill_parm to the $adparm from the menu
+bill_parm = $adparm1
+
+getparm(parmfile)
+getoption(option)
+
+if tracepath dp then
+   $trace("on,path", tracepath)
 endif
 
-'Check that the Add Parm 1 value is something we expect.  If not, give the error message and terminate the script.
-'This section also uses the Parm 1 value to determine the expected file name and the expected path
+' if we don't have a bill parm ask for one if the config says it's ok to ask
+if bill_parm !DP and promptforparm = "Y" then
+   bill_parm = askforparm()
+endif
 
-bill_parm = $adparm1
+' panic if we still don't have a bill parm
+if bill_parm !dp then
+   ShowMessageWin("Billing Parm File Not Specified",,"Print this Screen and Contact MIS")
+   return
+endif
 
 'check the billing parm file for the parameter "SEQOUT", if it is present, put the value into the CheckFile variable.
 'We should probably do some error checking to handle situations when the SEQOUT parmaeter is not present.  If this is the case, 
 'The process should notify the user and then abort (return).
 
-rc = $getparm(,bill_parm, "SEQOUT", CheckFile)
-
-if rc >= 2
+if $getparm(,bill_parm, "SEQOUT", CheckFile) >= 2 then
    ShowMessageWin("SEQOUT Parm Not in Parmfile",,"Print this Screen and Contact MIS")
    return
 endif

--- a/AnsiWrap.usc
+++ b/AnsiWrap.usc
@@ -38,14 +38,38 @@ FixCMD         is x   'Unix command for fixing output file
 Version        is x   '5010 or 4010
 ParmArray[]    is x   'Array for building a parameter file
 VerParm        is x   'Parameter file name
-bill_parm      is x   'Billing Parm file to use selected from either $adparm1 or $adparm2
-tempfile       is x   'Temporary file for the FixCmd
 
+nsa837p5       is x
+nsa837p5parm   is x
+
+misprogerr[]   is x
+
+bill-parm      is x   'Billing Parm file to use selected from either $adparm1 or $adparm2
+tempfile       is x   'Temporary file for the FixCmd
 tracepath      is x
+
 promptforparm  is x
+requirebillparm   is x
+
+prescript[]    is x
+postscript[]   is x
 
 'Default the bill_parm to the $adparm from the menu
-bill_parm = $adparm1
+nsa837p5 = "Y"
+'nsa837p5parm = $adparm1
+bill-parm = $adparm1
+
+misprogerr[1 ] = "The mis-prog-ref isn't in the program control file"
+misprogerr[2 ] = "Operator isn't authorized to initiate this program"
+misprogerr[3 ] = "This function isn't permitted if $sessiontabs is active"
+misprogerr[4 ] = "The program attempted is not allowed in $misprog (e.g. menu)"
+misprogerr[5 ] = "$misprog cannot be executed while $setmis is in effect"
+misprogerr[6 ] = "Program is browser only and session is in character mode"
+misprogerr[7 ] = "Program is non-browser mode and session is in browser mode"
+misprogerr[8 ] = "Error bidding the CMHC/MIS program"
+misprogerr[9 ] = "Program control file error"
+misprogerr[10] = "The session is a CRON, but the requested CMHC/MIS program cannot be run in CRON mode"
+misprogerr[11] = "More than one left-frame menu referenced"
 
 getparm(parmfile)
 getoption(option)
@@ -54,38 +78,49 @@ if tracepath dp then
    $trace("on,path", tracepath)
 endif
 
-' if we don't have a bill parm ask for one if the config says it's ok to ask
-if bill_parm !DP and promptforparm = "Y" then
-   bill_parm = askforparm()
+if nsa837p5parm dp then
+   bill-parm = nsa837p5parm
+endif
+
+'' if we don't have a bill parm ask for one if the config says it's ok to ask
+if bill-parm !DP and promptforparm = "Y" then
+      $openwin(win1, 5, 25, 4, 64)
+      $disp("Billing Parm:", 6, 5,,"H")
+      $acpt(bill-parm, 6, 20, 8)
+      if bill-parm !dp then 
+         retcode = 98
+         return
+      endif
 endif
 
 ' panic if we still don't have a bill parm
-if bill_parm !dp then
-   ShowMessageWin("Billing Parm File Not Specified",,"Print this Screen and Contact MIS")
-   return
-endif
+'if nsa837p5parm !dp and requirebillparm != "N" then
+   'ShowMessageWin("Billing Parm File Not Specified",,"Print this Screen and Contact MIS")
+   'retcode = 98
+   'return
+'endif
 
 'check the billing parm file for the parameter "SEQOUT", if it is present, put the value into the CheckFile variable.
 'We should probably do some error checking to handle situations when the SEQOUT parmaeter is not present.  If this is the case, 
 'The process should notify the user and then abort (return).
 
-if $getparm(,bill_parm, "SEQOUT", CheckFile) >= 2 then
+if $getparm(,bill-parm, "SEQOUT", CheckFile) >= 2 then
    ShowMessageWin("SEQOUT Parm Not in Parmfile",,"Print this Screen and Contact MIS")
    return
 endif
 
 ' Use the filename from the parameter file if not overritten in this script.
-if CheckFile DP and FileName !DP then
-   FileName = CheckFile
-else
-   CheckFile = FileName
-   FileName = FilePath + FileName
-endif
+'if CheckFile DP and FileName !DP then
+   'FileName = CheckFile
+'else
+   'CheckFile = FileName
+   'FileName = FilePath + FileName
+'endif
 
 'Check to see if the file is there.  If it is, give the error message and terminate the script.
 'If it is not, allow the 837P proess to continue with the parm in Add Parm 1.
 
-rc = $checkfile(FileName,FileSize,FileCreateDT,FileCreateTM,,,FileOwner)
+rc = $checkfile(CheckFile,FileSize,FileCreateDT,FileCreateTM,,,FileOwner)
 
 if rc = 0                 'If the file already exists, issue the error message and instructions to the user
    $openwin(win1, 5, 25, 4, 64)
@@ -98,51 +133,49 @@ if rc = 0                 'If the file already exists, issue the error message a
    $disp(`"File Owner: " + FileOwner`, 12, 5,,"H")
    $disp("Print this Screen and Contact MIS", 19, 5,,"H")
    $acpt()
-	return
+   retcode = 99
+   return
 endif                
 
 'If the billfile is not there, go ahead and dynamically create the bill parm that tells the process to run as
 '5010 or 4010
 
+'process the prescripts
+rc = 0
+do while rc++ < $maxarray(prescript[])
+   call prescript[rc] (parmfile, option, checkfile, retcode)
+enddo
+
+verparm = parmfile
+if nsa837p5parm !dp then
    ParmArray[1] = "NSA837P5"
-   ParmArray[2] = "NSA837P5PARM " + bill_parm
+   ParmArray[2] = "NSA837P5PARM " + bill-parm
    VerParm = "VP5010"
-
    rc = $putparm(ParmArray[],VerParm,"R")
-
-   CreateBill = $misprog(474,VerParm)
-   if CreateBill = 0 then
-
-      rc = $tempfile(tempfile)
-      FixCmd = "sed 's/BK:ICD10:/ABK:/g' " + Filename + " > " + tempfile + " ; cp " + tempfile + " " + Filename
-
-      ' Have a post fix command to run
-      if FixCMD DP then
-         if dofield013 = "Y"
-            rc = $unix(FixCmd)         
-         endif
-      endif
-   else
-      ' Show a error message
-      select CreateBill
-         case 1         $errmsg1 = "The mis-prog-ref isn't in the program control file"
-         case 2         $errmsg1 = "Operator isn't authorized to initiate this program"
-         case 3         $errmsg1 = "This function isn't permitted if $sessiontabs is active"
-         case 4         $errmsg1 = "The program attempted is not allowed in $misprog (e.g. menu)"
-         case 5         $errmsg1 = "$misprog cannot be executed while $setmis is in effect"
-         case 6         $errmsg1 = "Program is browser only and session is in character mode"
-         case 7         $errmsg1 = "Program is non-browser mode and session is in browser mode"
-         case 8         $errmsg1 = "Error bidding the CMHC/MIS program"
-         case 9         $errmsg1 = "Program control file error"
-         case 10        $errmsg1 = "The session is a CRON, but the requested CMHC/MIS program cannot be run in CRON mode"
-         case 11        $errmsg1 = "More than one left-frame menu referenced"
-         case other     $errmsg1 = $format(rc, "Unknown error (99)")
-      endselect
-   endif
 endif
 
-EndScript:
+CreateBill = $misprog(474,VerParm)
+'createbill = $misprog(474, parmfile)
+
+if createbill > 0 then
+   $errmsg1 = misprogerr[rc]
+   if $errmsg1 !dp then
+      $errmsg1 = $format(rc, "Unknown error (99)")
+   endif
+   retcode = rc
+   return
+endif
+
+'process the postscripts
+rc = 0
+do while rc++ < $maxarray(postscript[])
+   call postscript[rc] (parmfile, option, checkfile, retcode)
+enddo
+
 end AnsiWrap
+
+%include inc_GetParm
+%include inc_GetOption
 
 function ShowMessageWin(msg1, msg2, msg3, msg4) is null
 '--- function arguments ---

--- a/deploy.js
+++ b/deploy.js
@@ -1,0 +1,31 @@
+var util = require('mis-util');
+var config = require('./config.ignore');
+
+var options = {
+   sysname: '/c1/FRSH',
+   connect: {
+      host: 'gccmhc',
+      user: 'tim',
+      password: config.user
+   },
+   cron: {
+      user: 'datamgr',
+      pass: config.cron
+   },
+   view_path: {
+      local: './view/',
+      remote: '/CUST/forms/'
+   },
+   parm_path: {
+      local: './build/'
+   },
+   usc_path: {
+      local: './'
+   }
+};
+
+var mis = util(options);
+
+console.log('deploying to: ' + options.sysname);
+
+mis.script.install('./AnsiWrap.usc');

--- a/readme.md
+++ b/readme.md
@@ -1,0 +1,79 @@
+# Txace ICD10 Project
+## ICD-10 ANSI
+
+### Documentation & Setup
+
+ANSI processing it the ICD-10 is really two separate processes (uScripts).  The two uScripts are AnsiWrap and ANSIDX10.  AnsiWrap is optional and not required to generate claims with the necessary components to send ICD-10 codes for services after 10/1/2015.  But it does contain some functionality that some may find helpful.  The ANSIDX10 uScript is required in order to send claims with the appropriate ICD-9 or ICD=10 code and with the correct code set identifier.
+
+#### Prerequisites
+
+1. ISN Registers MUST be in place for each Event to be billed
+
+2. The latest version of lib_DX10 installed and compiled. In this library
+
+3. ANSIP is patched up to patch 422415 (3/30/2015)
+
+4. The latest version of inc_DX10 installed on your system
+
+5. RU2DXTYPE recode table will need to be created.  `I` is the input type `X` is the output type.  This table is used to recode the RU into one of the values `MH`, `ID` or `SA`.
+
+6. This ANSIDX10 will ONLY use the new ICD-10 CMHC Record.  So it should ONLY be run AFTER your ICD-10 conversion process has been run in production.  This conversion should ONLY be run after your table t_ICD-10_ICD-9_with_GEM_AXIS has been updated with correct DX Categories using the script from GitHub ICD010-9_Sync_DX_CAT.sql.
+
+7. AnsiWrap cannot be run from a cron.  It must be on a menu even when testing.
+
+![AnsiWrap File Replacement Error](https://github.com/txace/txace-images/blob/master/ansiwrap-file-replacement-error.png)
+
+#### uScript 
+
+##### AnsiWrap
+
+This uScript provides for some functionality that some users may find helpful
+
+1. It checks for a billing file of the same name and path in the UNIX filesystem that will be created by the billing process.  If the file is present, the user is presented with a file replacement error message that provides the file date, file time and file owner.  This prevents staff from inadvertently overwriting a billing file that may not yet have been sent.  See an example of this error message below.  Note, this is an error message.  Hitting any key while on this message will cause the script to stop processing and no ANSI file will be created.
+
+2. The process will create the needed “Version Parmfile” that tells the ANSI Processor that a 5010 compliant file will need to be created and provides the Billing Parmfile to the process. This process makes no provision for ANSI 4010 processing as this should no longer be needed.  Using this uScript will prevent staff from seeing the screen where they must indicate 4010 or 5010  version of the 837 file.  See example of Screen that still will NOT see below.
+  
+![Ansi 837 Version Prompt Screen](https://github.com/txace/txace-images/blob/master/ansi-837-version-prompt-screen.png')
+
+3. While these two benefits seem small, they can be a significant time saver because staff are not allowed to make certain mistakes.
+
+##### ANSIDX10
+
+Certain Logic will be required to send correct diagnostic information in our ANSI Billing files.  Information points that this uScript considers before determining the appropriate data to send are:
+
+1. Event Date: It gets this information from the ISN associated with the event.  
+
+  -.  If the ISN Event date is >= 10/1/2015 the ICD-10 Code is sent and the code set identifier of ABK is also sent.
+  -.  If the ISN Event date is < 10/1/2015, the ICD-9 code is sent and the code set identifier of BK is sent.
+
+2. Is this an MH, ID or SA Service?  The ISN RU from the ISN associated with the event is recoded into the value of MH, ID or SA.  This value is used to select the highest ranking DX code for the event that matches the DX_Category. 
+
+
+*NOTE* Set the variable dx10date as 10/01/2015 for production.  This date can be changed during testing.
+
+#### Bill Parm Setup
+
+The ANSIDX10 script is called by the ANSI P program.  There are two fields that must be in your Bill Parmfile.
+
+```
+102 013 07100                                        US=ANSIDX10 DX Codeset
+102 001 07100                                        US=ANSIDX10 DX Code
+```
+
+#### Menu Setup
+
+1.  Enter 466 as the program, Enter the desired security level and enter AnsiWrap() as the uScript name in the parameter section.
+
+![AnsiWrap Menu Setup](https://github.com/txace/txace-images/blob/master/ansiwrap-menu-setup.png)
+
+2. On the Update Additional Parameters Screen, enter your Bill Parameter File name under Add Parm 1.  The example below, the bill parameter name is MCODX10
+    
+![AnsiWrap Menu Additional Parm Setup](https://github.com/txace/txace-images/blob/master/ansiwrap-menu-additional-setup.png)
+
+#### Tracing & Logging
+
+If tracing and/or logging is desired, set a value for the variables `tracefile` or `logfile`. If these values are not data present, no logging or tracing will occur.
+
+*NOTE* If tracing is desired, it should be noted that the `tracefile` will get replaced each time the script is executed.  And the script will be executed twice for each event in the billing file.  Therefore, tracing should only be activated for a single client and single event.  Additionally, one of the lines with US=ANSIDX10 should be commented out so that the tracefile only shows the result of a single execution.
+
+Logging may provide more comprehensive information since the log file is not replaced for each execution of the uScript.  However, it simply shows the value being handed to the uScript (ISN ID) and the value that is returned to the ANSIP program (BK:ICD-9 code or ABK:ICD-10 Code)

--- a/readme.md
+++ b/readme.md
@@ -31,7 +31,7 @@ This uScript provides for some functionality that some users may find helpful
 
 1. It checks for a billing file of the same name and path in the UNIX filesystem that will be created by the billing process.  If the file is present, the user is presented with a file replacement error message that provides the file date, file time and file owner.  This prevents staff from inadvertently overwriting a billing file that may not yet have been sent.  See an example of this error message below.  Note, this is an error message.  Hitting any key while on this message will cause the script to stop processing and no ANSI file will be created.
 
-2. The process will create the needed “Version Parmfile” that tells the ANSI Processor that a 5010 compliant file will need to be created and provides the Billing Parmfile to the process. This process makes no provision for ANSI 4010 processing as this should no longer be needed.  Using this uScript will prevent staff from seeing the screen where they must indicate 4010 or 5010  version of the 837 file.  See example of Screen that still will NOT see below.
+2. The process will create the needed 'Version Parmfile' that tells the ANSI Processor that a 5010 compliant file will need to be created and provides the Billing Parmfile to the process. This process makes no provision for ANSI 4010 processing as this should no longer be needed.  Using this uScript will prevent staff from seeing the screen where they must indicate 4010 or 5010  version of the 837 file.  See example of Screen that still will NOT see below.
   
 ![Ansi 837 Version Prompt Screen](https://github.com/txace/txace-images/blob/master/ansi-837-version-prompt-screen.png)
 
@@ -43,8 +43,9 @@ Certain Logic will be required to send correct diagnostic information in our ANS
 
 1. Event Date: It gets this information from the ISN associated with the event.  
 
-  -.  If the ISN Event date is >= 10/1/2015 the ICD-10 Code is sent and the code set identifier of ABK is also sent.
-  -.  If the ISN Event date is < 10/1/2015, the ICD-9 code is sent and the code set identifier of BK is sent.
+  - If the ISN Event date is >= 10/1/2015 the ICD-10 Code is sent and the code set identifier of ABK is also sent.
+
+  - If the ISN Event date is < 10/1/2015, the ICD-9 code is sent and the code set identifier of BK is sent.
 
 2. Is this an MH, ID or SA Service?  The ISN RU from the ISN associated with the event is recoded into the value of MH, ID or SA.  This value is used to select the highest ranking DX code for the event that matches the DX_Category. 
 

--- a/readme.md
+++ b/readme.md
@@ -37,6 +37,15 @@ This uScript provides for some functionality that some users may find helpful
 
 3. While these two benefits seem small, they can be a significant time saver because staff are not allowed to make certain mistakes.
 
+###### AnsiWrap Parameter Options
+
+| name | Possible Values | Description |
+| ---- | --------------- | ----------- |
+| prescript-# | valid uscript name | List of uscripts you want to be executed prior to calling the 837 Program. The output sequential file is passed in as the 3rd argument of the script |
+| postscript-# | valid uscript name | List of uscripts you want to be executed after to calling the 837 Program. The output sequential file is passed in as the 3rd argument of the script |
+| nsa837p5parm | Valid 837 Billing Parm | Alternative to setting the billing parm on the menu. If this parm is set it will use this value for the Billing Parm for the 837 program |
+| promptforparm | Y or !DP | Option to turn on the character based screen for prompting the user to enter the billing parm. If promptforparm is _not_ set to 'Y' and the billing parm is not set by $adparm1 or by nsa837p5parm the script will error |
+
 ##### ANSIDX10
 
 Certain Logic will be required to send correct diagnostic information in our ANSI Billing files.  Information points that this uScript considers before determining the appropriate data to send are:
@@ -70,6 +79,8 @@ The ANSIDX10 script is called by the ANSI P program.  There are two fields that 
 2. On the Update Additional Parameters Screen, enter your Bill Parameter File name under Add Parm 1.  The example below, the bill parameter name is MCODX10
     
 ![AnsiWrap Menu Additional Parm Setup](https://github.com/txace/txace-images/blob/master/ansiwrap-menu-additional-setup.png)
+
+*NOTE* Step 2 is optional if you use either the nsa837p5parm or promptforparm options of the AnsiWrap Script.
 
 #### Tracing & Logging
 

--- a/readme.md
+++ b/readme.md
@@ -33,7 +33,7 @@ This uScript provides for some functionality that some users may find helpful
 
 2. The process will create the needed “Version Parmfile” that tells the ANSI Processor that a 5010 compliant file will need to be created and provides the Billing Parmfile to the process. This process makes no provision for ANSI 4010 processing as this should no longer be needed.  Using this uScript will prevent staff from seeing the screen where they must indicate 4010 or 5010  version of the 837 file.  See example of Screen that still will NOT see below.
   
-![Ansi 837 Version Prompt Screen](https://github.com/txace/txace-images/blob/master/ansi-837-version-prompt-screen.png')
+![Ansi 837 Version Prompt Screen](https://github.com/txace/txace-images/blob/master/ansi-837-version-prompt-screen.png)
 
 3. While these two benefits seem small, they can be a significant time saver because staff are not allowed to make certain mistakes.
 


### PR DESCRIPTION
```
~ AnsiWrap enhancements for gcc
   most of these are to help gcc work around the bk/abk issue

   + standard argument string `parmfile, option, retcode`
   + pre/post script functionality
   + nsa837p5 and nsa837p5parm variables
      > these allow the script to pass in the parmfile variable
         to the $misprog function instead of having to
         create a parm specifing the billing parm
   + logic to prompt the user for a billing parm file if one
      is not provided in the $adparm1 or nsa837p5parm
   + promptforparm setting to toggle if the script will ask the
      user for a parm name if there is not one present
   - removed some unused logic on the checkfile / seqout file
   + new logic to only create the temporary parm to pass to $misprog
      when a parmname is _NOT_ passed into nsa837p5parm
      (when $adparm1 is used)
   ~ rearranged the $misprog error handling logic to use an array
      instead of a case statement
```

all of these changes _should_ be compatible with the previous version
